### PR TITLE
Update deprecated usage of __pry__ to pry_instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ end
 
 # Hit Enter to repeat last command
 Pry::Commands.command /^$/, "repeat last command" do
-_pry_.run_command Pry.history.to_a.last
+  pry_instance.run_command Pry.history.to_a.last
 end
 
 ```


### PR DESCRIPTION
`__pry__` was deprecated in [v0.13.0](https://github.com/pry/pry/blob/master/CHANGELOG.md#v0130-march-21-2020). This  PR updates the example `~/.pryrc` in `README.md` to reflect this change. Using the supplied example will throw a deprecation warning when using the super cool "repeat last command" functionality.